### PR TITLE
Feature/cm110 ewf alb

### DIFF
--- a/groups/ewf-infrastructure/alb-internal.tf
+++ b/groups/ewf-infrastructure/alb-internal.tf
@@ -1,0 +1,97 @@
+# ------------------------------------------------------------------------------
+# EWF Security Group and rules
+# ------------------------------------------------------------------------------
+module "ewf_internal_alb_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.application}-internal-alb-001"
+  description = "Security group for the ${var.application} web servers"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = local.admin_cidrs
+  ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+  egress_rules        = ["all-all"]
+}
+
+#--------------------------------------------
+# Internal ALB EWF
+#--------------------------------------------
+module "ewf_internal_alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "alb-${var.application}-internal-001"
+  internal                   = true
+  load_balancer_type         = "application"
+  enable_deletion_protection = true
+
+  security_groups = [module.ewf_internal_alb_security_group.this_security_group_id]
+  subnets         = data.aws_subnet_ids.public.ids
+
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "HTTP"
+      target_group_index = 0
+      action_type        = "redirect"
+      redirect = {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    },
+  ]
+
+  https_listeners = [
+    {
+      port               = 443
+      protocol           = "HTTPS"
+      certificate_arn    = data.aws_acm_certificate.acm_cert.arn
+      target_group_index = 0
+    },
+  ]
+
+  target_groups = [
+    {
+      name_prefix          = "h1"
+      backend_protocol     = "HTTP"
+      backend_port         = var.backend_port
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        path                = var.health_check_path
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        timeout             = 6
+        protocol            = "HTTP"
+        matcher             = "200-399"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+  ]
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-DBA-Support"
+    )
+  )
+}
+
+#--------------------------------------------
+# Internal ALB CloudWatch Merics
+#--------------------------------------------
+module "internal_alb_metrics" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/alb-metrics?ref=tags/1.0.26"
+
+  load_balancer_id = module.ewf_internal_alb.this_lb_id
+  target_group_ids = module.ewf_internal_alb.target_group_arns
+
+  depends_on = [module.ewf_internal_alb]
+}

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -9,14 +9,13 @@ module "ewf_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.cidr_block
+  ingress_cidr_blocks = [var.cidr_block]
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }
 
 data "aws_acm_certificate" "acm_cert" {
   domain = var.domain_name
-  types  = "IMPORTED"
 }
 
 #--------------------------------------------

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -60,13 +60,13 @@ module "ewf_alb" {
     {
       name_prefix          = "h1"
       backend_protocol     = "HTTP"
-      backend_port         = 80
+      backend_port         = var.backend_port
       target_type          = "instance"
       deregistration_delay = 10
       health_check = {
         enabled             = true
         interval            = 30
-        path                = "/health"
+        path                = var.health_check_path
         port                = 80
         healthy_threshold   = 3
         unhealthy_threshold = 3
@@ -81,7 +81,7 @@ module "ewf_alb" {
   ]
 
   tags = {
-    Environment = "Test"
+    Environment = var.environment
   }
 }
 

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -1,0 +1,145 @@
+# ------------------------------------------------------------------------------
+# EWF Security Group and rules
+# ------------------------------------------------------------------------------
+module "ewf_web_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.application}-web-001"
+  description = "Security group for the ${var.application} web servers"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = local.admin_cidrs
+  ingress_rules       = ["ewf-web-tcp"]
+  egress_rules        = ["all-all"]
+}
+
+#--------------------------------------------
+# ALB EWF
+#--------------------------------------------
+module "ewf_alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "EWF-ALB"
+  internal                   = false
+  load_balancer_type         = "application"
+  enable_deletion_protection = true
+
+  security_groups = [module.ewf_web_security_group.id]
+  subnets         = data.aws_subnet_ids.data.ids
+
+  # Accessing logs to S3
+  access_logs {
+    bucket = aws_s3_bucket.alb_logs.bucket # Does this exist ?
+    prefix = "ewf-alb"
+  }
+
+  tags {
+    Name        = "EWFWeb"
+    Environment = "Test"
+  }
+}
+
+#--------------------------------------------
+# Launch Configuration 
+#--------------------------------------------
+resource "aws_launch_configuration" "ewf-launchconfig" {
+  name = "ewf-launchconfig"
+  depends_on    = [module.ewf_web_security_group]
+  image_id      = lookup(var.AMIS, var.AWS_REGION)
+  instance_type = "t2.micro"
+  security_groups = [module.ewf_web_security_group.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+#--------------------------------------------
+# Auto Scaling Group
+#--------------------------------------------
+resource "aws_autoscaling_group" "ewf-asg" {
+  name                      = "ewf-asg"
+  depends_on                = [aws_launch_configuration.ewf-launchconfig]
+  vpc_zone_identifier       = data.aws_subnet_ids.data.ids
+  max_size                  = 2
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  load_balancers            = [module.ewf_alb.name]
+  force_delete              = true
+  launch_configuration      = aws_launch_configuration.ewf-launchconfig.id
+  target_group_arns         = [aws_lb_target_group.ewf-tg.arn]
+
+  tags = {
+    key                 = "Name"
+    value               = "ewf web instance"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+#--------------------------------------------
+# Target Group
+#--------------------------------------------
+resource "aws_lb_target_group" "ewf-tg" {
+  name        = "ewf-tg"
+  port        = 443
+  protocol    = "HTTPS"
+  vpc_id      = data.aws_vpc.vpc.id
+  target_type = "instance"
+  # Health Checks  
+  health_check {
+    interval            = 30
+    path                = "/healthcheck"
+    port                = 80
+    protocol            = "HTTP"
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    timeout             = 5
+    matcher             = "200,202"
+  }
+}
+
+#-----------------------------------------------------
+# Assignment of the EWF instances to the target group
+#-----------------------------------------------------
+resource "aws_lb_target_group_attachment" "ewf-alb-target-attachement" {
+  target_group_arn = aws_lb_target_group.ewf-tg.arn
+  #   target_id        = aws_instance.ewf-web.id
+  target_id = aws_instance.ewf-web.id
+  port      = 80
+}
+
+#--------------------------------------------
+# ALB Listener
+#--------------------------------------------
+resource "aws_lb_listener" "ewf-alb-listener" {
+
+  depends_on        = [aws_lb_target_group.ewf-tg.id]
+  load_balancer_arn = module.ewf_alb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "EWFWebSecurityPolicy"
+  #   certificate_arn	    = aws_iam_server_certificate.ewf_web_certs.arn
+  default_action {
+    target_group_arn = aws_lb_target_group.ewf-tg.arn
+    type             = "forward"
+  }
+}
+
+#--------------------------------------------
+# ALB CloudWatch Merics
+#--------------------------------------------
+module "alb_metrics" {
+  source = "../../../terraform-modules/aws/alb-metrics"
+
+  load_balancer_id = module.alb.this_lb_id
+  target_group_ids = module.alb.target_group_arns
+
+  depends_on = [module.ewf_alb]
+}

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -1,17 +1,30 @@
+data "aws_route53_zone" "this" {
+  name = local.domain_name
+}
+
 # ------------------------------------------------------------------------------
 # EWF Security Group and rules
 # ------------------------------------------------------------------------------
-module "ewf_web_security_group" {
+module "ewf_alb_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 3.0"
 
-  name        = "sgr-${var.application}-web-001"
+  name        = "sgr-${var.application}-alb-001"
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
   ingress_cidr_blocks = local.admin_cidrs
-  ingress_rules       = ["ewf-web-tcp"]
+  ingress_rules       = ["http-80-tcp", "all-icmp"]
   egress_rules        = ["all-all"]
+}
+
+# AWS ACM Module
+module "acm" {
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> 2.0"
+
+  domain_name = local.domain_name
+  zone_id     = data.aws_route53_zone.this.id
 }
 
 #--------------------------------------------
@@ -21,22 +34,62 @@ module "ewf_alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
 
-  name                       = "EWF-ALB"
+  name                       = "alb-${var.application}-001"
   internal                   = false
   load_balancer_type         = "application"
   enable_deletion_protection = true
 
-  security_groups = [module.ewf_web_security_group.id]
+  security_groups = [module.ewf_alb_security_group.this_security_group_id]
   subnets         = data.aws_subnet_ids.data.ids
 
-  # Accessing logs to S3
-  access_logs {
-    bucket = aws_s3_bucket.alb_logs.bucket # Does this exist ?
-    prefix = "ewf-alb"
-  }
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "HTTP"
+      target_group_index = 0
+      action_type = "redirect"
+      redirect = {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    },
+  ]
 
-  tags {
-    Name        = "EWFWeb"
+  https_listeners = [
+    {
+      port               = 443
+      protocol           = "HTTPS"
+      certificate_arn    = module.acm.this_acm_certificate_arn
+      target_group_index = 1
+    },
+  ]
+  
+  target_groups = [
+    {
+      name_prefix          = "h1"
+      backend_protocol     = "HTTP"
+      backend_port         = 80
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        path                = "/health"
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        timeout             = 6
+        protocol            = "HTTP"
+        matcher             = "200-399"
+      }
+      tags = {
+        InstanceTargetGroupTag = "ewf"
+      }
+    },
+  ]
+
+  tags = {
     Environment = "Test"
   }
 }
@@ -44,102 +97,91 @@ module "ewf_alb" {
 #--------------------------------------------
 # Launch Configuration 
 #--------------------------------------------
-resource "aws_launch_configuration" "ewf-launchconfig" {
-  name = "ewf-launchconfig"
-  depends_on    = [module.ewf_web_security_group]
-  image_id      = lookup(var.AMIS, var.AWS_REGION)
-  instance_type = "t2.micro"
-  security_groups = [module.ewf_web_security_group.id]
+# resource "aws_launch_configuration" "ewf-launchconfig" {
+#   name = "ewf-launchconfig"
+#   depends_on    = [module.ewf_alb_security_group]
+#   image_id      = lookup(var.AMIS, var.AWS_REGION)
+#   instance_type = "t2.micro"
+#   security_groups = [module.ewf_alb_security_group.id]
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
 #--------------------------------------------
 # Auto Scaling Group
 #--------------------------------------------
-resource "aws_autoscaling_group" "ewf-asg" {
-  name                      = "ewf-asg"
-  depends_on                = [aws_launch_configuration.ewf-launchconfig]
-  vpc_zone_identifier       = data.aws_subnet_ids.data.ids
-  max_size                  = 2
-  min_size                  = 2
-  health_check_grace_period = 300
-  health_check_type         = "ELB"
-  load_balancers            = [module.ewf_alb.name]
-  force_delete              = true
-  launch_configuration      = aws_launch_configuration.ewf-launchconfig.id
-  target_group_arns         = [aws_lb_target_group.ewf-tg.arn]
+# resource "aws_autoscaling_group" "ewf-asg" {
+#   name                      = "ewf-asg"
+#   depends_on                = [aws_launch_configuration.ewf-launchconfig]
+#   vpc_zone_identifier       = data.aws_subnet_ids.data.ids
+#   max_size                  = 2
+#   min_size                  = 2
+#   health_check_grace_period = 300
+#   health_check_type         = "ELB"
+#   load_balancers            = [module.ewf_alb.name]
+#   force_delete              = true
+#   launch_configuration      = aws_launch_configuration.ewf-launchconfig.id
+#   target_group_arns         = [aws_lb_target_group.ewf-tg.arn]
 
-  tags = {
-    key                 = "Name"
-    value               = "ewf web instance"
-    propagate_at_launch = true
-  }
+#   tags = {
+#     key                 = "Name"
+#     value               = "ewf web instance"
+#     propagate_at_launch = true
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
 #--------------------------------------------
 # Target Group
 #--------------------------------------------
-resource "aws_lb_target_group" "ewf-tg" {
-  name        = "ewf-tg"
-  port        = 443
-  protocol    = "HTTPS"
-  vpc_id      = data.aws_vpc.vpc.id
-  target_type = "instance"
-  # Health Checks  
-  health_check {
-    interval            = 30
-    path                = "/healthcheck"
-    port                = 80
-    protocol            = "HTTP"
-    healthy_threshold   = 5
-    unhealthy_threshold = 2
-    timeout             = 5
-    matcher             = "200,202"
-  }
-}
-
-#-----------------------------------------------------
-# Assignment of the EWF instances to the target group
-#-----------------------------------------------------
-resource "aws_lb_target_group_attachment" "ewf-alb-target-attachement" {
-  target_group_arn = aws_lb_target_group.ewf-tg.arn
-  #   target_id        = aws_instance.ewf-web.id
-  target_id = aws_instance.ewf-web.id
-  port      = 80
-}
+# resource "aws_lb_target_group" "ewf-tg" {
+#   name        = "ewf-tg"
+#   port        = 443
+#   protocol    = "HTTPS"
+#   vpc_id      = data.aws_vpc.vpc.id
+#   target_type = "instance"
+#   # Health Checks  
+#   health_check {
+#     interval            = 30
+#     path                = "/healthcheck"
+#     port                = 80
+#     protocol            = "HTTP"
+#     healthy_threshold   = 5
+#     unhealthy_threshold = 2
+#     timeout             = 5
+#     matcher             = "200,202"
+#   }
+# }
 
 #--------------------------------------------
 # ALB Listener
 #--------------------------------------------
-resource "aws_lb_listener" "ewf-alb-listener" {
+# resource "aws_lb_listener" "ewf-alb-listener" {
 
-  depends_on        = [aws_lb_target_group.ewf-tg.id]
-  load_balancer_arn = module.ewf_alb.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "EWFWebSecurityPolicy"
-  #   certificate_arn	    = aws_iam_server_certificate.ewf_web_certs.arn
-  default_action {
-    target_group_arn = aws_lb_target_group.ewf-tg.arn
-    type             = "forward"
-  }
-}
+#   load_balancer_arn = module.ewf_alb.arn
+#   port              = "80"
+#   protocol          = "HTTP"
+#   ssl_policy        = "EWFALBSecurityPolicy"
+#   #   certificate_arn	    = aws_iam_server_certificate.ewf_web_certs.arn
+#   default_action {
+#     target_group_arn = aws_lb_target_group.ewf-tg.arn
+#     type             = "forward"
+#   }
+# }
 
 #--------------------------------------------
 # ALB CloudWatch Merics
 #--------------------------------------------
 module "alb_metrics" {
-  source = "../../../terraform-modules/aws/alb-metrics"
+  source = "git@github.com:companieshouse/terraform-modules//aws/alb-metrics"
 
-  load_balancer_id = module.alb.this_lb_id
-  target_group_ids = module.alb.target_group_arns
+  load_balancer_id = module.ewf_alb.this_lb_id
+  target_group_ids = module.ewf_alb.target_group_arns
 
   depends_on = [module.ewf_alb]
 }

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -9,7 +9,7 @@ module "ewf_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = [var.cidr_block]
+  ingress_cidr_blocks = [var.public_cidr_block]
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }

--- a/groups/ewf-infrastructure/alb.tf
+++ b/groups/ewf-infrastructure/alb.tf
@@ -1,7 +1,3 @@
-data "aws_route53_zone" "this" {
-  name = local.domain_name
-}
-
 # ------------------------------------------------------------------------------
 # EWF Security Group and rules
 # ------------------------------------------------------------------------------
@@ -23,8 +19,8 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 2.0"
 
-  domain_name = local.domain_name
-  zone_id     = data.aws_route53_zone.this.id
+  domain_name = local.internal_fqdn
+  zone_id     = data.aws_route53_zone.private_zone.id
 }
 
 #--------------------------------------------
@@ -47,7 +43,7 @@ module "ewf_alb" {
       port               = 80
       protocol           = "HTTP"
       target_group_index = 0
-      action_type = "redirect"
+      action_type        = "redirect"
       redirect = {
         port        = "443"
         protocol    = "HTTPS"
@@ -64,7 +60,7 @@ module "ewf_alb" {
       target_group_index = 1
     },
   ]
-  
+
   target_groups = [
     {
       name_prefix          = "h1"
@@ -95,90 +91,10 @@ module "ewf_alb" {
 }
 
 #--------------------------------------------
-# Launch Configuration 
-#--------------------------------------------
-# resource "aws_launch_configuration" "ewf-launchconfig" {
-#   name = "ewf-launchconfig"
-#   depends_on    = [module.ewf_alb_security_group]
-#   image_id      = lookup(var.AMIS, var.AWS_REGION)
-#   instance_type = "t2.micro"
-#   security_groups = [module.ewf_alb_security_group.id]
-
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
-
-#--------------------------------------------
-# Auto Scaling Group
-#--------------------------------------------
-# resource "aws_autoscaling_group" "ewf-asg" {
-#   name                      = "ewf-asg"
-#   depends_on                = [aws_launch_configuration.ewf-launchconfig]
-#   vpc_zone_identifier       = data.aws_subnet_ids.data.ids
-#   max_size                  = 2
-#   min_size                  = 2
-#   health_check_grace_period = 300
-#   health_check_type         = "ELB"
-#   load_balancers            = [module.ewf_alb.name]
-#   force_delete              = true
-#   launch_configuration      = aws_launch_configuration.ewf-launchconfig.id
-#   target_group_arns         = [aws_lb_target_group.ewf-tg.arn]
-
-#   tags = {
-#     key                 = "Name"
-#     value               = "ewf web instance"
-#     propagate_at_launch = true
-#   }
-
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
-
-#--------------------------------------------
-# Target Group
-#--------------------------------------------
-# resource "aws_lb_target_group" "ewf-tg" {
-#   name        = "ewf-tg"
-#   port        = 443
-#   protocol    = "HTTPS"
-#   vpc_id      = data.aws_vpc.vpc.id
-#   target_type = "instance"
-#   # Health Checks  
-#   health_check {
-#     interval            = 30
-#     path                = "/healthcheck"
-#     port                = 80
-#     protocol            = "HTTP"
-#     healthy_threshold   = 5
-#     unhealthy_threshold = 2
-#     timeout             = 5
-#     matcher             = "200,202"
-#   }
-# }
-
-#--------------------------------------------
-# ALB Listener
-#--------------------------------------------
-# resource "aws_lb_listener" "ewf-alb-listener" {
-
-#   load_balancer_arn = module.ewf_alb.arn
-#   port              = "80"
-#   protocol          = "HTTP"
-#   ssl_policy        = "EWFALBSecurityPolicy"
-#   #   certificate_arn	    = aws_iam_server_certificate.ewf_web_certs.arn
-#   default_action {
-#     target_group_arn = aws_lb_target_group.ewf-tg.arn
-#     type             = "forward"
-#   }
-# }
-
-#--------------------------------------------
 # ALB CloudWatch Merics
 #--------------------------------------------
 module "alb_metrics" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/alb-metrics"
+  source = "git@github.com:companieshouse/terraform-modules//aws/alb-metrics?ref=tags/1.0.25"
 
   load_balancer_id = module.ewf_alb.this_lb_id
   target_group_ids = module.ewf_alb.target_group_arns

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -9,8 +9,14 @@ module "ewf_asg_security_group" {
   description = "Security group for the ${var.application} asg"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = [var.cidr_block]
-  ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "http-80-tcp"
+      source_security_group_id = module.ewf_alb_security_group.this_security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+
   egress_rules        = ["all-all"]
 }
 
@@ -64,5 +70,5 @@ module "asg" {
 
 resource "aws_key_pair" "asg_keypair" {
   key_name   = format("%s-%s", var.application, "asg")
-  public_key = local.asg_keypair_input_data["public-key"]
+  public_key = local.ewf_ec2_data["public-key"]
 }

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -1,0 +1,44 @@
+# ASG Module
+module "asg" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "~> 3.0"
+  name = "ewf-webserver"
+  # Launch configuration
+  lc_name = "ewf-launchconfig"
+  image_id          = data.aws_ami.ewf.id
+  instance_type     = "t2.micro"
+  security_groups   = [module.ewf_alb_security_group.this_security_group_id]
+  ebs_block_device = [
+    {
+      device_name           = "/dev/xvdz"
+      volume_type           = "gp2"
+      volume_size           = "50"
+      delete_on_termination = true
+    },
+  ]
+  root_block_device = [
+    {
+      volume_size = "50"
+      volume_type = "gp2"
+    },
+  ]
+  # Auto scaling group
+  asg_name                  = "ewf-asg"
+  depends_on                = [module.ewf_alb]
+  vpc_zone_identifier       = data.aws_subnet_ids.data.ids
+  health_check_type         = "EC2"
+  min_size                  = 0
+  max_size                  = 2
+  desired_capacity          = 2
+  health_check_grace_period = 300
+  wait_for_capacity_timeout = 0
+  force_delete              = true
+  target_group_arns         = module.ewf_alb.target_group_arns
+  tags = [
+    {
+      key                 = "Name"
+      value               = "ewf web instance"
+      propagate_at_launch = true
+    }
+  ] 
+}

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -62,12 +62,12 @@ module "asg" {
   key_name                  = aws_key_pair.asg_keypair.key_name
   termination_policies      = ["OldestLaunchConfiguration"]
   target_group_arns         = module.ewf_alb.target_group_arns
-  # iam_instance_profile      = module.ewf_fe_cloudwatchlogs.iam_instance_profile.name
+  iam_instance_profile      = module.ewf_frontend_profile.aws_iam_instance_profile.name
   user_data = templatefile("${path.module}/templates/user_data.tpl",
     {
       REGION         = var.aws_region
       TNS_NAMES      = templatefile("${path.module}/templates/tns.tpl", local.tns_connections) //data.null_data_source.ewf_frontend.outputs["tnsnames"],
-      SERVER_NAME    = "123"
+      SERVER_NAME    = "${var.application}.${data.aws_route53_zone.private_zone.name}"
       LOG_GROUP_NAME = "logs-${var.application}-frontend"
     }
   )

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -1,13 +1,29 @@
+# ------------------------------------------------------------------------------
+# EWF Security Group and rules
+# ------------------------------------------------------------------------------
+module "ewf_asg_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.application}-asg-001"
+  description = "Security group for the ${var.application} asg"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = var.cidr_block
+  ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+  egress_rules        = ["all-all"]
+}
+
 # ASG Module
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
   version = "~> 3.0"
-  name    = "ewf-webserver"
+  name    = "${var.application}-webserver"
   # Launch configuration
-  lc_name         = "ewf-launchconfig"
+  lc_name         = "${var.application}-launchconfig"
   image_id        = data.aws_ami.ewf.id
   instance_type   = "t2.micro"
-  security_groups = [module.ewf_alb_security_group.this_security_group_id]
+  security_groups = [module.ewf_asg_security_group.this_security_group_id]
   ebs_block_device = [
     {
       device_name           = "/dev/xvdz"
@@ -23,9 +39,9 @@ module "asg" {
     },
   ]
   # Auto scaling group
-  asg_name                  = "ewf-asg"
+  asg_name                  = "${var.application}-asg"
   depends_on                = [module.ewf_alb]
-  vpc_zone_identifier       = data.aws_subnet_ids.data.ids
+  vpc_zone_identifier       = data.aws_subnet_ids.web.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 2
@@ -33,12 +49,20 @@ module "asg" {
   health_check_grace_period = 300
   wait_for_capacity_timeout = 0
   force_delete              = true
+  key_name                  = aws_key_pair.asg_keypair.key_name
+  termination_policies      = ["OldestLaunchConfiguration"]
   target_group_arns         = module.ewf_alb.target_group_arns
-  tags = [
-    {
-      key                 = "Name"
-      value               = "ewf web instance"
-      propagate_at_launch = true
-    }
-  ]
+
+  tags_as_map = merge(
+    local.default_tags,
+    map(
+      "Name", "${var.application}-web-instance",
+      "ServiceTeam", "${upper(var.application)}-EC2-Support"
+    )
+  )
+}
+
+resource "aws_key_pair" "asg_keypair" {
+  key_name   = format("%s-%s", var.application, "asg")
+  public_key = local.asg_keypair_input_data["public-key"]
 }

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -22,7 +22,7 @@ module "asg" {
   # Launch configuration
   lc_name         = "${var.application}-launchconfig"
   image_id        = data.aws_ami.ewf.id
-  instance_type   = "t2.micro"
+  instance_type   = var.instance_size
   security_groups = [module.ewf_asg_security_group.this_security_group_id]
   ebs_block_device = [
     {
@@ -43,9 +43,9 @@ module "asg" {
   depends_on                = [module.ewf_alb]
   vpc_zone_identifier       = data.aws_subnet_ids.web.ids
   health_check_type         = "EC2"
-  min_size                  = 0
-  max_size                  = 2
-  desired_capacity          = 2
+  min_size                  = var.min_size
+  max_size                  = var.max_size
+  desired_capacity          = var.desired_capacity
   health_check_grace_period = 300
   wait_for_capacity_timeout = 0
   force_delete              = true

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -30,17 +30,9 @@ module "asg" {
   image_id        = data.aws_ami.ewf.id
   instance_type   = var.instance_size
   security_groups = [module.ewf_asg_security_group.this_security_group_id]
-  ebs_block_device = [
-    {
-      device_name           = "/dev/xvdz"
-      volume_type           = "gp2"
-      volume_size           = "50"
-      delete_on_termination = true
-    },
-  ]
   root_block_device = [
     {
-      volume_size = "50"
+      volume_size = "40"
       volume_type = "gp2"
     },
   ]

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -12,10 +12,14 @@ module "ewf_asg_security_group" {
   computed_ingress_with_source_security_group_id = [
     {
       rule                     = "http-80-tcp"
-      source_security_group_id = module.ewf_alb_security_group.this_security_group_id
+      source_security_group_id = module.ewf_internal_alb_security_group.this_security_group_id
+    },
+    {
+      rule                     = "http-80-tcp"
+      source_security_group_id = module.ewf_external_alb_security_group.this_security_group_id
     }
   ]
-  number_of_computed_ingress_with_source_security_group_id = 1
+  number_of_computed_ingress_with_source_security_group_id = 2
 
   egress_rules = ["all-all"]
 }
@@ -61,7 +65,7 @@ module "asg" {
   force_delete              = true
   key_name                  = aws_key_pair.asg_keypair.key_name
   termination_policies      = ["OldestLaunchConfiguration"]
-  target_group_arns         = module.ewf_alb.target_group_arns
+  target_group_arns         = concat(module.ewf_external_alb.target_group_arns, module.ewf_internal_alb.target_group_arns)
   iam_instance_profile      = module.ewf_frontend_profile.aws_iam_instance_profile.name
   user_data = templatefile("${path.module}/templates/user_data.tpl",
     {

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -9,7 +9,7 @@ module "ewf_asg_security_group" {
   description = "Security group for the ${var.application} asg"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.cidr_block
+  ingress_cidr_blocks = [var.cidr_block]
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }

--- a/groups/ewf-infrastructure/asg.tf
+++ b/groups/ewf-infrastructure/asg.tf
@@ -2,12 +2,12 @@
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
   version = "~> 3.0"
-  name = "ewf-webserver"
+  name    = "ewf-webserver"
   # Launch configuration
-  lc_name = "ewf-launchconfig"
-  image_id          = data.aws_ami.ewf.id
-  instance_type     = "t2.micro"
-  security_groups   = [module.ewf_alb_security_group.this_security_group_id]
+  lc_name         = "ewf-launchconfig"
+  image_id        = data.aws_ami.ewf.id
+  instance_type   = "t2.micro"
+  security_groups = [module.ewf_alb_security_group.this_security_group_id]
   ebs_block_device = [
     {
       device_name           = "/dev/xvdz"
@@ -40,5 +40,5 @@ module "asg" {
       value               = "ewf web instance"
       propagate_at_launch = true
     }
-  ] 
+  ]
 }

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -56,7 +56,7 @@ data "vault_generic_secret" "asg_keypair_input_data" {
 # Example AMI from AWS marketplace used for testing until EWF AMI is available
 data "aws_ami" "ewf" {
   most_recent = true
-  owners      = ["self"]
+  owners      = ["amazon"]
   filter {
     name = "name"
     values = [
@@ -66,7 +66,7 @@ data "aws_ami" "ewf" {
   filter {
     name = "owner-alias"
     values = [
-      "self",
+      "amazon",
     ]
   }
 }

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -50,7 +50,7 @@ data "vault_generic_secret" "internal_cidrs" {
 }
 
 data "vault_generic_secret" "asg_keypair_input_data" {
-  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/asg"
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/ec2"
 }
 
 # Example AMI from AWS marketplace used for testing until EWF AMI is available

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -56,6 +56,10 @@ data "vault_generic_secret" "ewf_ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/ec2"
 }
 
+data "aws_acm_certificate" "acm_cert" {
+  domain = var.domain_name
+}
+
 data "aws_ami" "ewf" {
   most_recent = true
   owners      = [data.vault_generic_secret.account_ids.data["development"]]

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -49,7 +49,7 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
-data "vault_generic_secret" "asg_keypair_input_data" {
+data "vault_generic_secret" "ewf_ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/ec2"
 }
 

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -56,7 +56,6 @@ data "vault_generic_secret" "ewf_ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/ec2"
 }
 
-# Example AMI from AWS marketplace used for testing until EWF AMI is available
 data "aws_ami" "ewf" {
   most_recent = true
   owners      = [data.vault_generic_secret.account_ids.data["development"]]

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -12,6 +12,22 @@ data "aws_subnet_ids" "data" {
   }
 }
 
+data "aws_subnet_ids" "public" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-public-*"]
+  }
+}
+
+data "aws_subnet_ids" "web" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-web-*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true
@@ -33,10 +49,14 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "asg_keypair_input_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/asg"
+}
+
 # Example AMI from AWS marketplace used for testing until EWF AMI is available
 data "aws_ami" "ewf" {
   most_recent = true
-  owners      = ["amazon"]
+  owners      = ["self"]
   filter {
     name = "name"
     values = [
@@ -46,7 +66,7 @@ data "aws_ami" "ewf" {
   filter {
     name = "owner-alias"
     values = [
-      "amazon",
+      "self",
     ]
   }
 }

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -70,3 +70,10 @@ data "aws_ami" "ewf" {
     ]
   }
 }
+
+# Gather details about TNS names for the environment
+data "null_data_source" "ewf_frontend" {
+  inputs = {
+    tnsnames = templatefile("${path.module}/templates/tns.tpl", local.tns_connections)
+  }
+}

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -32,3 +32,21 @@ data "vault_generic_secret" "ewf_rds" {
 data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
+
+# Example AMI from AWS marketplace used for testing until EWF AMI is available
+data "aws_ami" "ewf" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name = "name"
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+  filter {
+    name = "owner-alias"
+    values = [
+      "amazon",
+    ]
+  }
+}

--- a/groups/ewf-infrastructure/iam.tf
+++ b/groups/ewf-infrastructure/iam.tf
@@ -1,18 +1,18 @@
-# module "ewf-fe-logging" {
-#     source = "git@github.com:companieshouse/terraform-modules//aws/instance-profile?ref=tags/1.0.30"
+module "ewf_frontend_profile" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.31"
 
-#     name      = "ewf-fe-cw-logs"
-#     statement = [
-#         { 
-#             sid = "ewfloggroupwrite"
-#             effect = "Allow"
-#             resources = [
-#                 aws_cloudwatch_log_group.ewf_fe.arn
-#             ]
-#             actions = [
-#                 "logs:CreateLogStream",
-#                 "logs:PutLogEvents",
-#             ]
-#         }
-#     ] 
-# }
+  name = "ewf_frontend_profile"
+  statement = [
+    {
+      sid    = "ewfloggroupwrite"
+      effect = "Allow"
+      resources = [
+        aws_cloudwatch_log_group.ewf_fe.arn
+      ]
+      actions = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ]
+    }
+  ]
+}

--- a/groups/ewf-infrastructure/iam.tf
+++ b/groups/ewf-infrastructure/iam.tf
@@ -1,0 +1,18 @@
+# module "ewf-fe-logging" {
+#     source = "git@github.com:companieshouse/terraform-modules//aws/instance-profile?ref=tags/1.0.30"
+
+#     name      = "ewf-fe-cw-logs"
+#     statement = [
+#         { 
+#             sid = "ewfloggroupwrite"
+#             effect = "Allow"
+#             resources = [
+#                 aws_cloudwatch_log_group.ewf_fe.arn
+#             ]
+#             actions = [
+#                 "logs:CreateLogStream",
+#                 "logs:PutLogEvents",
+#             ]
+#         }
+#     ] 
+# }

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -6,7 +6,7 @@ locals {
   ewf_rds_data  = data.vault_generic_secret.ewf_rds.data
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  asg_keypair_input_data = data.vault_generic_secret.asg_keypair_input_data.data
+  ewf_ec2_data = data.vault_generic_secret.ewf_ec2_data.data
 
   default_tags = {
     Terraform   = "true"

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -4,7 +4,7 @@
 locals {
   admin_cidrs  = values(data.vault_generic_secret.internal_cidrs.data)
   ewf_rds_data = data.vault_generic_secret.ewf_rds.data
-
+  domain_name = "terraform-aws-modules.modules.tf"
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   default_tags = {

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -2,11 +2,22 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  admin_cidrs   = values(data.vault_generic_secret.internal_cidrs.data)
-  ewf_rds_data  = data.vault_generic_secret.ewf_rds.data
+  admin_cidrs  = values(data.vault_generic_secret.internal_cidrs.data)
+  ewf_rds_data = data.vault_generic_secret.ewf_rds.data
+  ewf_tnsnames = jsondecode(local.ewf_rds_data["tnsnames"])
+  ewf_ec2_data = data.vault_generic_secret.ewf_ec2_data.data
+
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  ewf_ec2_data = data.vault_generic_secret.ewf_ec2_data.data
+  tns_connections = {
+    servers = [for connection in local.ewf_tnsnames.tnsnames : {
+      name         = connection.name,
+      address      = connection.address
+      service_name = connection.service_name
+      port         = connection.port
+      }
+    ]
+  }
 
   default_tags = {
     Terraform   = "true"

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -6,6 +6,8 @@ locals {
   ewf_rds_data  = data.vault_generic_secret.ewf_rds.data
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
+  asg_keypair_input_data = data.vault_generic_secret.asg_keypair_input_data.data
+
   default_tags = {
     Terraform   = "true"
     Application = upper(var.application)

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -2,9 +2,8 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  admin_cidrs  = values(data.vault_generic_secret.internal_cidrs.data)
-  ewf_rds_data = data.vault_generic_secret.ewf_rds.data
-  domain_name = "terraform-aws-modules.modules.tf"
+  admin_cidrs   = values(data.vault_generic_secret.internal_cidrs.data)
+  ewf_rds_data  = data.vault_generic_secret.ewf_rds.data
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   default_tags = {

--- a/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -26,7 +26,7 @@ multi_az = false
 
 # RDS Engine settings
 major_engine_version = "12.1"
-engine_version       = "12.1.0.2.v21"
+engine_version       = "12.1.0.2.v22"
 license_model        = "license-included"
 
 # RDS Param and Option settings

--- a/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -12,8 +12,8 @@ application = "ewf"
 environment = "development"
 
 # ASG settings
-instance_size = "t2.micro"
-min_size = 0
+instance_size = "t2.medium"
+min_size = 1
 max_size = 2
 desired_capacity = 2
 

--- a/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -11,6 +11,12 @@ region  = "euw2"
 application = "ewf"
 environment = "development"
 
+# ASG settings
+instance_size = "t2.micro"
+min_size = 0
+max_size = 2
+desired_capacity = 2
+
 # RDS Instance settings
 instance_class = "db.t3.medium"
 allocated_storage = 20

--- a/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -11,6 +11,12 @@ region  = "euw2"
 application = "ewf"
 environment = "live"
 
+# ASG settings
+instance_size = "t2.micro"
+min_size = 0
+max_size = 2
+desired_capacity = 2
+
 # RDS Instance settings
 instance_class = "db.m5.xlarge"
 allocated_storage = 1500

--- a/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -26,7 +26,7 @@ multi_az = true
 
 # RDS Engine settings
 major_engine_version = "12.1"
-engine_version       = "12.1.0.2.v21"
+engine_version       = "12.1.0.2.v22"
 license_model        = "license-included"
 
 # RDS Param and Option settings

--- a/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -12,8 +12,8 @@ application = "ewf"
 environment = "live"
 
 # ASG settings
-instance_size = "t2.micro"
-min_size = 0
+instance_size = "t2.medium"
+min_size = 1
 max_size = 2
 desired_capacity = 2
 

--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -26,7 +26,7 @@ multi_az = true
 
 # RDS Engine settings
 major_engine_version = "12.1"
-engine_version       = "12.1.0.2.v21"
+engine_version       = "12.1.0.2.v22"
 license_model        = "license-included"
 
 # RDS Param and Option settings

--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -12,8 +12,8 @@ application = "ewf"
 environment = "staging"
 
 # ASG settings
-instance_size = "t2.micro"
-min_size = 0
+instance_size = "t2.medium"
+min_size = 1
 max_size = 2
 desired_capacity = 2
 

--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -11,6 +11,12 @@ region  = "euw2"
 application = "ewf"
 environment = "staging"
 
+# ASG settings
+instance_size = "t2.micro"
+min_size = 0
+max_size = 2
+desired_capacity = 2
+
 # RDS Instance settings
 instance_class = "db.m5.large"
 allocated_storage = 250

--- a/groups/ewf-infrastructure/route53.tf
+++ b/groups/ewf-infrastructure/route53.tf
@@ -5,3 +5,11 @@ resource "aws_route53_record" "ewf_rds" {
   ttl     = "300"
   records = [module.ewf_rds.this_db_instance_address]
 }
+
+resource "aws_route53_record" "ewf_alb_internal" {
+  zone_id = data.aws_route53_zone.private_zone.zone_id
+  name    = var.application
+  type    = "CNAME"
+  ttl     = "300"
+  records = [module.ewf_alb.this_lb_dns_name]
+}

--- a/groups/ewf-infrastructure/route53.tf
+++ b/groups/ewf-infrastructure/route53.tf
@@ -11,5 +11,5 @@ resource "aws_route53_record" "ewf_alb_internal" {
   name    = var.application
   type    = "CNAME"
   ttl     = "300"
-  records = [module.ewf_alb.this_lb_dns_name]
+  records = [module.ewf_internal_alb.this_lb_dns_name]
 }

--- a/groups/ewf-infrastructure/templates/tns.tpl
+++ b/groups/ewf-infrastructure/templates/tns.tpl
@@ -1,0 +1,13 @@
+%{ for server in servers ~}
+${server.name} = 
+  (DESCRIPTION =
+    (ADDRESS_LIST =
+      (ADDRESS = (PROTOCOL = TCP)(HOST = ${server.address})(PORT = ${server.port}))
+    )
+    (CONNECT_DATA =
+      (SERVICE_NAME = ${server.service_name})
+      (SERVER = DEDICATED)
+    )
+  )
+
+%{ endfor ~}

--- a/groups/ewf-infrastructure/templates/user_data.tpl
+++ b/groups/ewf-infrastructure/templates/user_data.tpl
@@ -8,10 +8,11 @@ aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $instance
 python cw_log_conf.py \
 -g ${LOG_GROUP_NAME} \
 -o "amazon-cloudwatch-agent.log" \
--l "/var/log/squid/access.log" "/var/log/squid/cache.log"
+-l "/var/log/httpd/ewf_access_log" "/var/log/httpd/ewf_error_log"
 . /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:amazon-cloudwatch-agent.log -s
 #Replace servername directive with correct value in httpd.conf
-REGEXREPLACE_SERVERNAME
 sed -i -e "s/REGEXREPLACE_SERVERNAME/${SERVER_NAME}/g" /etc/httpd/conf/httpd.conf
 #Create the TNSNames.ora file for Oracle
-echo ${TNS_NAMES} > /usr/lib/oracle/11.2/client64/lib/tnsnames.ora
+cat <<EOF >>/usr/lib/oracle/11.2/client64/lib/tnsnames.ora
+${TNS_NAMES}
+EOF

--- a/groups/ewf-infrastructure/templates/user_data.tpl
+++ b/groups/ewf-infrastructure/templates/user_data.tpl
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-# Disable source / destination check. It cannot be disabled from the launch configuration and is required to intercept traffic
-instanceid=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
-aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $instanceid --region ${REGION}
 #Generate new cloudwatch conf file with updated log group and load into cw agent service
 python cw_log_conf.py \
 -g ${LOG_GROUP_NAME} \

--- a/groups/ewf-infrastructure/templates/user_data.tpl
+++ b/groups/ewf-infrastructure/templates/user_data.tpl
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Redirect the user-data output to the console logs
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+# Disable source / destination check. It cannot be disabled from the launch configuration and is required to intercept traffic
+instanceid=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $instanceid --region ${REGION}
+#Generate new cloudwatch conf file with updated log group and load into cw agent service
+python cw_log_conf.py \
+-g ${LOG_GROUP_NAME} \
+-o "amazon-cloudwatch-agent.log" \
+-l "/var/log/squid/access.log" "/var/log/squid/cache.log"
+. /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:amazon-cloudwatch-agent.log -s
+#Replace servername directive with correct value in httpd.conf
+REGEXREPLACE_SERVERNAME
+sed -i -e "s/REGEXREPLACE_SERVERNAME/${SERVER_NAME}/g" /etc/httpd/conf/httpd.conf
+#Create the TNSNames.ora file for Oracle
+echo ${TNS_NAMES} > /usr/lib/oracle/11.2/client64/lib/tnsnames.ora

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -134,7 +134,7 @@ variable "backend_port" {
   description = "Target group backend port"
 }
 
-variable "cidr_block" {
+variable "public_cidr_block" {
   type        = string
   default     = "0.0.0.0/0"
   description = "cidr block for allowing inbound users from internet"

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -113,6 +113,6 @@ variable "cidr_block" {
 
 variable "domain_name" {
   type        = string
-  default     = "companieshouse.gov.uk"
+  default     = "*.companieshouse.gov.uk"
   description = "Domain Name for ACM Certificate"
 }

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -101,3 +101,18 @@ variable "vault_password" {
   type        = string
   description = "Password for connecting to Vault - usually supplied through TF_VARS"
 }
+
+# ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "cidr_block" {
+  type        = string
+  default     = "0.0.0.0/0"
+  description = "cidr block for allowing inbound users from internet"
+}
+
+variable "domain_name" {
+  type        = string
+  default     = "companieshouse.gov.uk"
+  description = "Domain Name for ACM Certificate"
+}

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -1,4 +1,17 @@
 # ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault - usually supplied through TF_VARS"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault - usually supplied through TF_VARS"
+}
+
+# ------------------------------------------------------------------------------
 # AWS Variables
 # ------------------------------------------------------------------------------
 variable "aws_region" {
@@ -113,19 +126,7 @@ variable "license_model" {
 }
 
 # ------------------------------------------------------------------------------
-# Vault Variables
-# ------------------------------------------------------------------------------
-variable "vault_username" {
-  type        = string
-  description = "Username for connecting to Vault - usually supplied through TF_VARS"
-}
-variable "vault_password" {
-  type        = string
-  description = "Password for connecting to Vault - usually supplied through TF_VARS"
-}
-
-# ------------------------------------------------------------------------------
-# ALB Variables
+# EWF Frontend Variables - ALB 
 # ------------------------------------------------------------------------------
 
 variable "backend_port" {
@@ -150,4 +151,10 @@ variable "health_check_path" {
   type        = string
   default     = "/"
   description = "Target group health check path"
+}
+
+variable "log_group_retention_in_days" {
+  type        = number
+  default     = 7
+  description = "Total days to retain logs in CloudWatch log group"
 }

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -44,6 +44,28 @@ variable "environment" {
   description = "The name of the environment"
 }
 
+# ASG Variables
+variable "instance_size" {
+  type        = string
+  description = "The size of the ec2 instance"
+}
+
+variable "min_size" {
+  type        = number
+  description = "The min size of the ASG"
+}
+
+variable "max_size" {
+  type        = number
+  description = "The max size of the ASG"
+}
+
+variable "desired_capacity" {
+  type        = number
+  description = "The desired capacity of ASG"
+}
+
+
 # ------------------------------------------------------------------------------
 # RDS Variables
 # ------------------------------------------------------------------------------
@@ -103,8 +125,15 @@ variable "vault_password" {
 }
 
 # ------------------------------------------------------------------------------
-# Vault Variables
+# ALB Variables
 # ------------------------------------------------------------------------------
+
+variable "backend_port" {
+  type        = number
+  default     = 80
+  description = "Target group backend port"
+}
+
 variable "cidr_block" {
   type        = string
   default     = "0.0.0.0/0"
@@ -115,4 +144,10 @@ variable "domain_name" {
   type        = string
   default     = "*.companieshouse.gov.uk"
   description = "Domain Name for ACM Certificate"
+}
+
+variable "health_check_path" {
+  type        = string
+  default     = "/"
+  description = "Target group health check path"
 }


### PR DESCRIPTION
**Terraform Plan below:** 


`Terraform will perform the following actions:

  # module.acm.aws_acm_certificate.this[0] will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "development.heritage.aws.internal"
      + domain_validation_options = [
          + {
              + domain_name           = "development.heritage.aws.internal"
              + resource_record_name  = (known after apply)
              + resource_record_type  = (known after apply)
              + resource_record_value = (known after apply)
            },
        ]
      + id                        = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"

      + options {
          + certificate_transparency_logging_preference = "ENABLED"
        }
    }

  # module.acm.aws_acm_certificate_validation.this[0] will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + validation_record_fqdns = (known after apply)
    }

  # module.acm.aws_route53_record.validation[0] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z09594542P3VH6DQCXTBA"
    }

  # module.acm.aws_route53_record.validation[1] will be created
  + resource "aws_route53_record" "validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z09594542P3VH6DQCXTBA"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.active_connection_count will be created
  + resource "aws_cloudwatch_metric_alarm" "active_connection_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API response time is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "ActiveConnectionCount"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.client_tls_neg_err_count will be created
  + resource "aws_cloudwatch_metric_alarm" "client_tls_neg_err_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API response time is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "ClientTLSNegotiationErrorCount"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.healthy_host_count[0] will be created
  + resource "aws_cloudwatch_metric_alarm" "healthy_host_count" {
      + actions_enabled                       = true
      + alarm_description                     = (known after apply)
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "LessThanOrEqualToThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "HealthyHostCount"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Average"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.httpcode_target_4xx_count[0] will be created
  + resource "aws_cloudwatch_metric_alarm" "httpcode_target_4xx_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API 4XX target group error code count is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "HTTPCode_Target_4XX_Count"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.httpcode_target_5xx_count[0] will be created
  + resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API 5XX target group error code count is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "HTTPCode_Target_5XX_Count"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.latency will be created
  + resource "aws_cloudwatch_metric_alarm" "latency" {
      + actions_enabled                       = true
      + alarm_description                     = "The number of targets that are considered healthy"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "ELBAuthLatency"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Average"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.request_count will be created
  + resource "aws_cloudwatch_metric_alarm" "request_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API 5XX target group error code count is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "RequestCount"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.target_response_time[0] will be created
  + resource "aws_cloudwatch_metric_alarm" "target_response_time" {
      + actions_enabled                       = true
      + alarm_description                     = (known after apply)
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "TargetResponseTime"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Average"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.alb_metrics.aws_cloudwatch_metric_alarm.target_tls_neg_err_count[0] will be created
  + resource "aws_cloudwatch_metric_alarm" "target_tls_neg_err_count" {
      + actions_enabled                       = true
      + alarm_description                     = "Average API response time is too high"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 5
      + id                                    = (known after apply)
      + metric_name                           = "TargetTLSNegotiationErrorCount"
      + namespace                             = "AWS/ApplicationELB"
      + period                                = 60
      + statistic                             = "Sum"
      + threshold                             = 50
      + treat_missing_data                    = "missing"
    }

  # module.asg.aws_autoscaling_group.this[0] will be created
  + resource "aws_autoscaling_group" "this" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = 300
      + desired_capacity          = 2
      + enabled_metrics           = [
          + "GroupDesiredCapacity",
          + "GroupInServiceInstances",
          + "GroupMaxSize",
          + "GroupMinSize",
          + "GroupPendingInstances",
          + "GroupStandbyInstances",
          + "GroupTerminatingInstances",
          + "GroupTotalInstances",
        ]
      + force_delete              = true
      + health_check_grace_period = 300
      + health_check_type         = "EC2"
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_instance_lifetime     = 0
      + max_size                  = 2
      + metrics_granularity       = "1Minute"
      + min_elb_capacity          = 0
      + min_size                  = 0
      + name                      = (known after apply)
      + name_prefix               = "ewf-asg-"
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + target_group_arns         = (known after apply)
      + termination_policies      = [
          + "Default",
        ]
      + vpc_zone_identifier       = [
          + "subnet-025dbe71b0a807304",
          + "subnet-04fc1aebef4c0da11",
          + "subnet-07f66f2cd8d88ece2",
        ]
      + wait_for_capacity_timeout = "0"

      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "ewf web instance"
        }
      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "ewf-webserver"
        }
    }

  # module.asg.aws_launch_configuration.this[0] will be created
  + resource "aws_launch_configuration" "this" {
      + arn                         = (known after apply)
      + associate_public_ip_address = false
      + ebs_optimized               = false
      + enable_monitoring           = true
      + id                          = (known after apply)
      + image_id                    = "ami-0ab68e2316d772a16"
      + instance_type               = "t2.micro"
      + key_name                    = (known after apply)
      + name                        = (known after apply)
      + name_prefix                 = "ewf-launchconfig-"
      + placement_tenancy           = "default"
      + security_groups             = (known after apply)

      + ebs_block_device {
          + delete_on_termination = true
          + device_name           = "/dev/xvdz"
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + snapshot_id           = (known after apply)
          + volume_size           = 50
          + volume_type           = "gp2"
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + volume_size           = 50
          + volume_type           = "gp2"
        }
    }

  # module.ewf_alb.aws_lb.this[0] will be created
  + resource "aws_lb" "this" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = false
      + enable_deletion_protection = true
      + enable_http2               = true
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = "ipv4"
      + load_balancer_type         = "application"
      + name                       = "alb-ewf-001"
      + security_groups            = (known after apply)
      + subnets                    = [
          + "subnet-025dbe71b0a807304",
          + "subnet-04fc1aebef4c0da11",
          + "subnet-07f66f2cd8d88ece2",
        ]
      + tags                       = {
          + "Environment" = "Test"
          + "Name"        = "alb-ewf-001"
        }
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }

      + timeouts {
          + create = "10m"
          + delete = "10m"
          + update = "10m"
        }
    }

  # module.ewf_alb.aws_lb_listener.frontend_http_tcp[0] will be created
  + resource "aws_lb_listener" "frontend_http_tcp" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 80
      + protocol          = "HTTP"
      + ssl_policy        = (known after apply)

      + default_action {
          + order = (known after apply)
          + type  = "redirect"

          + redirect {
              + host        = "#{host}"
              + path        = "/#{path}"
              + port        = "443"
              + protocol    = "HTTPS"
              + query       = "#{query}"
              + status_code = "HTTP_301"
            }
        }
    }

  # module.ewf_alb.aws_lb_listener.frontend_https[0] will be created
  + resource "aws_lb_listener" "frontend_https" {
      + arn               = (known after apply)
      + certificate_arn   = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 443
      + protocol          = (known after apply)
      + ssl_policy        = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = (known after apply)
        }
      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = (known after apply)
        }
    }

  # module.ewf_alb.aws_lb_target_group.main[0] will be created
  + resource "aws_lb_target_group" "main" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + deregistration_delay               = 10
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = (known after apply)
      + name_prefix                        = "h1"
      + port                               = 80
      + protocol                           = "HTTP"
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags                               = {
          + "Environment"            = "Test"
          + "InstanceTargetGroupTag" = "ewf"
          + "Name"                   = "h1"
        }
      + target_type                        = "instance"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 30
          + matcher             = "200-399"
          + path                = "/health"
          + port                = "80"
          + protocol            = "HTTP"
          + timeout             = 6
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # module.ewf_alb_security_group.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for the ewf web servers"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "sgr-ewf-alb-001-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "sgr-ewf-alb-001"
        }
      + vpc_id                 = "vpc-072a23b32e2695955"
    }

  # module.ewf_alb_security_group.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.ewf_alb_security_group.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.172.16.0/24",
          + "10.172.116.0/22",
          + "172.16.0.0/12",
          + "10.172.20.0/22",
        ]
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.ewf_alb_security_group.aws_security_group_rule.ingress_rules[1] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.172.16.0/24",
          + "10.172.116.0/22",
          + "172.16.0.0/12",
          + "10.172.20.0/22",
        ]
      + description              = "All IPV4 ICMP"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "icmp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "ingress"
    }

Plan: 23 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------`