### PR TITLE
Sec group module does not accept null, logic checks length of list so blank list is better choice

### DIFF
--- a/groups/ewf-infrastructure/alb-internal.tf
+++ b/groups/ewf-infrastructure/alb-internal.tf
@@ -14,7 +14,7 @@ module "ewf_internal_alb_security_group" {
 
   # This is a non-production ruleset, Forgerock ID Gateway access in Dev and Staging
   # When Forgerock goes into Live then the condition can be removed.
-  ingress_with_source_security_group_id = var.environment == "live" ? null : [
+  ingress_with_source_security_group_id = var.environment == "live" ? [] : [
     {
       rule                     = "http-80-tcp"
       source_security_group_id = data.aws_security_group.identity_gateway[0].id


### PR DESCRIPTION
Sec group module does not accept null, logic checks length of list so blank list is better choice