### PR TITLE
Enable Forgerock Access in Live

### DIFF
--- a/groups/ewf-infrastructure/alb-internal.tf
+++ b/groups/ewf-infrastructure/alb-internal.tf
@@ -12,9 +12,7 @@ module "ewf_internal_alb_security_group" {
   ingress_cidr_blocks = local.admin_cidrs
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 
-  # This is a non-production ruleset, Forgerock ID Gateway access in Dev and Staging
-  # When Forgerock goes into Live then the condition can be removed.
-  ingress_with_source_security_group_id = var.environment == "live" ? [] : [
+  ingress_with_source_security_group_id = [
     {
       rule                     = "http-80-tcp"
       source_security_group_id = data.aws_security_group.identity_gateway[0].id

--- a/groups/ewf-infrastructure/alb-internal.tf
+++ b/groups/ewf-infrastructure/alb-internal.tf
@@ -28,11 +28,11 @@ module "ewf_internal_alb_security_group" {
   ingress_with_source_security_group_id = [
     {
       rule                     = "http-80-tcp"
-      source_security_group_id = data.aws_security_group.identity_gateway[0].id
+      source_security_group_id = data.aws_security_group.identity_gateway.id
     },
     {
       rule                     = "https-443-tcp"
-      source_security_group_id = data.aws_security_group.identity_gateway[0].id
+      source_security_group_id = data.aws_security_group.identity_gateway.id
     }
   ]
 

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -73,10 +73,8 @@ data "aws_security_group" "adminsites" {
   }
 }
 
-# This is a non-production lookup, Forgerock ID Gateway access in Dev and Staging
-# When Forgerock goes into Live then the condition can be removed.
 data "aws_security_group" "identity_gateway" {
-  count = var.environment == "live" ? 0 : 1
+  count = 1
   name  = "identity-gateway-instance"
 }
 

--- a/groups/ewf-infrastructure/data.tf
+++ b/groups/ewf-infrastructure/data.tf
@@ -74,7 +74,6 @@ data "aws_security_group" "adminsites" {
 }
 
 data "aws_security_group" "identity_gateway" {
-  count = 1
   name  = "identity-gateway-instance"
 }
 


### PR DESCRIPTION
Removed conditional on forgerock security group data source and resource use
Retained "count" declaration to ensure consistent state in non-live environments