### PR TITLE
Allow Selenium Access to Development

### DIFF
--- a/groups/ewf-infrastructure/alb-internal.tf
+++ b/groups/ewf-infrastructure/alb-internal.tf
@@ -15,13 +15,13 @@ module "ewf_internal_alb_security_group" {
   ingress_with_cidr_blocks = [
     {
       rule        = "http-80-tcp"
-      description = "CHS applications"
-      cidr_blocks = join(",", local.chs_app_subnets)
+      description = "Application Access"
+      cidr_blocks = join(",", local.fe_alb_app_access)
     },
     {
       rule        = "https-443-tcp"
-      description = "CHS applications"
-      cidr_blocks = join(",", local.chs_app_subnets)
+      description = "Application Access"
+      cidr_blocks = join(",", local.fe_alb_app_access)
     }
   ]
 

--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -23,6 +23,7 @@ locals {
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   chs_app_subnets = values(jsondecode(data.vault_generic_secret.chs_vpc_subnets.data["applications"]))
+  fe_alb_app_access = concat(local.chs_app_subnets, var.fe_access_cidrs)
 
   rds_ingress_cidrs = concat(local.admin_cidrs, var.rds_onpremise_access)
 

--- a/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -22,6 +22,11 @@ public_allow_cidr_blocks = [
   "127.0.0.1/32"
 ]
 
+# CIDRs requiring FE access via the ALB
+fe_access_cidrs = [
+  "10.254.0.0/24"
+]
+
 # Backend ASG settings
 bep_instance_size = "t2.medium"
 bep_min_size = 1

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -236,6 +236,12 @@ variable "fe_cw_logs" {
   default     = {}
 }
 
+variable "fe_access_cidrs" {
+  type        = list(any)
+  description = "List of additional CIDRs requiring access via the internal ALB"
+  default     = []
+}
+
 # ------------------------------------------------------------------------------
 # EWF Backend Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added new `fe_access_cidrs` var to define a list of CIDRs requiring access to the FE via the ALB
Added `fe_alb_app_access` local var to combine `fe_access_cidrs` and `chs_app_subnets`
Populated `fe_access_cidrs` var for Development
Updated `ewf_internal_alb_security_group` module to use new local var and updated SG name