### PR TITLE
Disable Staging RDS Multi-AZ

### DIFF
--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -78,7 +78,7 @@ instance_class          = "db.m5.2xlarge"
 allocated_storage       = 250
 maximum_storage         = 300
 backup_retention_period = 7
-multi_az                = true
+multi_az                = false
 rds_maintenance_window  = "Wed:00:00-Wed:03:00"
 rds_backup_window       = "03:00-06:00"
 


### PR DESCRIPTION
Disable `multi_az` for Staging RDS instance as it is not required.