### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -170,6 +170,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -175,6 +175,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -86,7 +86,7 @@ rds_backup_window       = "03:00-06:00"
 major_engine_version        = "19"
 engine_version              = "19"
 license_model               = "license-included"
-auto_minor_version_upgrade  = true
+auto_minor_version_upgrade  = false
 
 # RDS Access
 rds_onpremise_access = [
@@ -188,6 +188,27 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
 
 fe_cw_logs = {
   "audit.log" = {

--- a/groups/ewf-infrastructure/rds.tf
+++ b/groups/ewf-infrastructure/rds.tf
@@ -98,35 +98,13 @@ module "ewf_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.ewf_rds_security_group.this_security_group_id]
     },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
-    },
-  ]
+  ], var.option_group_settings)
 
   tags = merge(
     local.default_tags,

--- a/groups/ewf-infrastructure/variables.tf
+++ b/groups/ewf-infrastructure/variables.tf
@@ -140,6 +140,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated `rds.tf` to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging