### PR TITLE
Compress cron entries so they fit in parameter store

### DIFF
--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -85,7 +85,7 @@ locals {
     frontend_ansible_inputs = jsonencode(local.ewf_fe_ansible_inputs)
     backend_inputs          = local.ewf_bep_data
     backend_ansible_inputs  = jsonencode(local.ewf_bep_ansible_inputs)
-    backend_cron_entries    = data.template_file.ewf_cron_file.rendered
+    backend_cron_entries    = base64gzip(data.template_file.ewf_cron_file.rendered)
     backend_fess_token      = data.vault_generic_secret.ewf_fess_data.data["fess_token"]
   }
 }

--- a/groups/ewf-infrastructure/templates/bep_user_data.tpl
+++ b/groups/ewf-infrastructure/templates/bep_user_data.tpl
@@ -7,7 +7,7 @@ GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --regi
 #Create key:value variable
 $${GET_PARAM_COMMAND} '${EWF_BACKEND_INPUTS_PATH}' > inputs.json
 #Create cron file and set crontab for EWF user:
-$${GET_PARAM_COMMAND} '${EWF_CRON_ENTRIES_PATH}' > /root/cronfile
+$${GET_PARAM_COMMAND} '${EWF_CRON_ENTRIES_PATH}' | base64 -d | gunzip > /root/cronfile
 crontab -u ewf /root/cronfile
 #Set FESS_TOKEN
 FESS_TOKEN=$($${GET_PARAM_COMMAND} '${EWF_FESS_TOKEN_PATH}')


### PR DESCRIPTION
The cron entries for live are too large to fit in parameter store as they stand, so this PR adds a change to compress/uncompress the data so that it fits.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2680