### PR TITLE
Compress EWF bep ansible inputs as can be over 4K in size

### DIFF
--- a/groups/ewf-infrastructure/locals.tf
+++ b/groups/ewf-infrastructure/locals.tf
@@ -84,7 +84,7 @@ locals {
     frontend_inputs         = local.ewf_fe_data
     frontend_ansible_inputs = jsonencode(local.ewf_fe_ansible_inputs)
     backend_inputs          = local.ewf_bep_data
-    backend_ansible_inputs  = jsonencode(local.ewf_bep_ansible_inputs)
+    backend_ansible_inputs  = base64gzip(jsonencode(local.ewf_bep_ansible_inputs))
     backend_cron_entries    = base64gzip(data.template_file.ewf_cron_file.rendered)
     backend_fess_token      = data.vault_generic_secret.ewf_fess_data.data["fess_token"]
   }

--- a/groups/ewf-infrastructure/templates/bep_user_data.tpl
+++ b/groups/ewf-infrastructure/templates/bep_user_data.tpl
@@ -22,7 +22,7 @@ rm /etc/httpd/conf.d/welcome.conf
 rm /etc/httpd/conf.d/ssl.conf
 rm /etc/httpd/conf.d/perl.conf
 #Run Ansible playbook for Backend deployment using provided inputs
-$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' | base64 -d | gunzip > /root/ansible_inputs.json
 echo "Deploying ${APP_VERSION}"
 /usr/local/bin/ansible-playbook /root/backend_deployment.yml -e '@/root/ansible_inputs.json'
 # Update hostname and reboot


### PR DESCRIPTION
Compress the bep ansible inputs as it is slightly above 4K in size and causes a failure during apply on staging (and would also in live) due to the number of log groups in the json.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2680