### PR TITLE
Scale webfiling temporarily for performance testing authentication in staging

### DIFF
--- a/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ewf-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -17,7 +17,7 @@ enable_sns_topic = "false"
 fe_instance_size = "t2.medium"
 fe_min_size = 1
 fe_max_size = 10
-fe_desired_capacity = 1
+fe_desired_capacity = 10
 
 # FE Load Balancer
 public_allow_cidr_blocks = [


### PR DESCRIPTION
Webfiling is crashing out before the authentication-service does in staging at the moment.

Scale desired instances to match live to hopefully allow the web server to better cope with traffic.

Just horizontal scaling not vertical

https://companieshouse.slack.com/archives/C05K57L4V1T/p1759921200533929